### PR TITLE
Sentry bug fixes

### DIFF
--- a/services/fishStockings.service.ts
+++ b/services/fishStockings.service.ts
@@ -195,7 +195,7 @@ export type FishStocking<
           },
           area: 'number|optional',
           length: 'number|optional',
-          category: 'string',
+          category: 'string|optional',
         },
       },
       geom: {
@@ -719,7 +719,7 @@ export default class FishStockingsService extends moleculer.Service {
           municipality: 'object',
           area: 'number|optional|convert',
           length: 'number|optional|convert',
-          category: 'string',
+          category: 'string|optional',
         },
       },
       geom: 'any',
@@ -848,7 +848,7 @@ export default class FishStockingsService extends moleculer.Service {
           },
           area: 'number|optional|convert',
           length: 'number|optional|convert',
-          category: 'string',
+          category: 'string|optional',
         },
       },
       batches: {

--- a/services/fishStockings.service.ts
+++ b/services/fishStockings.service.ts
@@ -208,11 +208,34 @@ export type FishStocking<
         type: 'any',
         virtual: true,
         hidden: 'byDefault',
-        get: async ({ entity, ctx }: FieldHookCallback) => {
-          return ctx.call('fishStockings.getWgsCoordinates', {
-            id: entity.id,
-          });
-        },
+        default: () => [],
+        async populate(ctx: Context, _values: any, fishStockings: FishStocking[]) {
+          try {
+            const adapter = await this.getAdapter();
+            const ids = fishStockings.map((fishStocking) => fishStocking.id);
+
+            const results = await adapter.client.raw(
+                `SELECT id, ST_AsGeoJSON(ST_Transform(geom, 4326)) AS geojson 
+               FROM fish_stockings
+               WHERE id IN (${ids.join(',')})`
+            );
+
+            const coordinatesById = results.rows.reduce((acc: any, row: any) => {
+              acc[row.id] = JSON.parse(row.geojson).coordinates;
+              return acc;
+            }, {});
+
+            return fishStockings.map((fishStocking) =>
+                coordinatesById[fishStocking.id] || null
+            );
+          } catch (error) {
+            this.logger.error(
+                'Error populating WGS84 coordinates for fishStockings:',
+                error
+            );
+            return null;
+          }
+        }
       },
       batches: {
         // TODO: could be actual jsonb field instead of batches table. This would make selection and updates much easier.


### PR DESCRIPTION
getWgsCoordinates buvo is seno mixino todel failindavo. Tos koordinates naudojamos publik endpointe ir pastaruoju metu labai daug sentry erroru pareina.

location.category buvo privalomas, bet dauguma senu zuvinimu location.category yra undefined, nes seniau nesaugom. Ir kai zuvinima registruojant pasirinkemas recent location vietoj to kad pasirinkti is zemelapio, tai zuvinimo registracija nufailina.