### PR TITLE
fix: deterministic default sort for fish stockings list

### DIFF
--- a/services/fishStockings.service.ts
+++ b/services/fishStockings.service.ts
@@ -1293,7 +1293,7 @@ export default class FishStockingsService extends moleculer.Service {
   @Method
   async handleSort(ctx: Context<any, UserAuthMeta>) {
     ctx.params = {
-      sort: '-createdAt',
+      sort: '-createdAt,-id',
       ...ctx.params,
     };
     return ctx;

--- a/services/fishStockings.service.ts
+++ b/services/fishStockings.service.ts
@@ -1293,7 +1293,7 @@ export default class FishStockingsService extends moleculer.Service {
   @Method
   async handleSort(ctx: Context<any, UserAuthMeta>) {
     ctx.params = {
-      sort: '-eventTime',
+      sort: '-createdAt',
       ...ctx.params,
     };
     return ctx;


### PR DESCRIPTION
## Problem

Inspectors (Aplinkos apsaugos departamentas, Žuvininkystės tarnyba prie LR ŽŪM) reported three issues with the general fish stockings list (**„žuvinimų žurnalas"**):

1. The list appears empty / with missing entries by default — entries only show up after filtering by water body or date.
2. Some entries **duplicate** in the list.
3. Some entries **disappear** from the list.

(A fourth complaint — *„nusimeta įveisimo laikas"* — is a separate data integrity issue, not addressed in this PR.)

## Root cause

All three symptoms above stem from the default sort in `handleSort`:

- **Issue 1**: Default sort `'-eventTime'` puts stockings scheduled far into the future on page 1, pushing recently registered entries off the visible page. Filtering shrinks the result set so relevant rows fit — explaining *"with filters it's OK"*.
- **Issues 2 & 3**: `ORDER BY eventTime DESC` (or any non-unique key) is **non-deterministic** when rows share the same value. Postgres returns ties in arbitrary order, so between page 1 and page 2 the same row can appear on both (duplicate) or be skipped entirely (disappear).

Location: [services/fishStockings.service.ts:1293-1300](services/fishStockings.service.ts#L1293-L1300)

## Fix

Two-part change to `handleSort` default:

```diff
- sort: '-eventTime',
+ sort: '-createdAt,-id',
```

- **`-createdAt`** — newly registered stockings appear at the top of the journal (matches the UX inspectors expect from a registration log).
- **`-id`** — secondary tie-breaker. `id` is unique, so the total order is deterministic across all paginated requests. No more duplicates / disappearing entries.

Frontend can still send an explicit `sort` param to override.

## Not addressed in this PR

The *„nusimeta įveisimo laikas"* (eventTime gets reset) complaint is a **data integrity** issue, not a list/pagination one. Likely candidates that need separate investigation:

- Inspector-assignment path in [updateFishStocking:638-648](services/fishStockings.service.ts#L638-L648) spreads `...ctx.params` which may include `eventTime: undefined`.
- Timezone parsing: column is `timestamp` ([20230405144107_setup.js:65](database/migrations/20230405144107_setup.js#L65)) while the field is declared `'string|required'` — TZ-less strings could shift by the local offset.

Will need concrete examples (which entry, before/after value, which operation) to fix properly. Separate PR after that.

## Test plan

- [ ] Open the žuvinimų žurnalas without filters — confirm the most recently registered stockings appear on page 1
- [ ] Register a new stocking — confirm it appears at the top of the unfiltered list immediately
- [ ] Paginate through the full list — confirm no duplicates, no gaps
- [ ] Reload the same page multiple times — confirm the order is stable
- [ ] Apply water body / date filter — confirm filtering still works
- [ ] Send an explicit `sort` query param from the frontend — confirm the override still wins