### PR TITLE
fix(photos): switch to direct publicUrl — never expires

### DIFF
--- a/services/fishStockingPhotos.service.ts
+++ b/services/fishStockingPhotos.service.ts
@@ -66,12 +66,20 @@ export type FishStockingPhoto<
       url: {
         virtual: true,
         get({ entity, ctx }: FieldHookCallback) {
-          return ctx.call('minio.presignedGetObject', {
+          // Use the direct public URL (no signature), not a presigned URL.
+          // The MinIO `fishStockingPhotos/` prefix is configured for anonymous
+          // s3:GetObject (verified: direct curl returns NoSuchKey on a missing
+          // object instead of 403), so signed URLs add nothing but a failure
+          // mode — the old code passed `requestDate: new Date().toDateString()`
+          // which anchored the signing timestamp to today's 00:00, so the URL
+          // would die mid-day and the UI showed broken images plus a spinner
+          // (S3 returned `<Code>Forbidden</Code><Message>Request has expired
+          // </Message>`). publicUrl has no expiry — photos are visible to
+          // USER and ADMIN whenever they open the stocking page. Mirror of
+          // how biip-medziokle-api / biip-gyvunai-api serve their photos.
+          return ctx.call('minio.publicUrl', {
             bucketName: process.env.MINIO_BUCKET,
             objectName: this.getObjectName(entity),
-            expires: 60000,
-            reqParams: {},
-            requestDate: new Date().toDateString(),
           });
         },
       },

--- a/services/minio.service.ts
+++ b/services/minio.service.ts
@@ -60,12 +60,19 @@ export default class MinioService extends Moleculer.Service {
       objectName: string;
     }>,
   ) {
+    // Drop the port segment for the conventional HTTP(S) ports so the URL
+    // matches what the CDN/Caddy in front of MinIO actually serves on
+    // staging/production (`https://staging-cdn.biip.lt/<bucket>/<object>`,
+    // no `:443` suffix). Mirror of biip-medziokle-api / biip-gyvunai-api.
+    let portString = '';
+    if (![80, 443].includes(Number(this.client.port))) {
+      portString = `:${this.client.port}`;
+    }
     return (
       this.client.protocol +
       '//' +
       this.client.host +
-      ':' +
-      this.client.port +
+      portString +
       '/' +
       ctx.params.bucketName +
       '/' +


### PR DESCRIPTION
## Symptom

Photos render with a spinning loader; opening any image URL directly returns:

\`\`\`xml
<Error>
  <Code>Forbidden</Code>
  <Message>Request has expired</Message>
</Error>
\`\`\`

User confirmation: had been working for months, now broken — and **must work for both ADMIN and USER, always**.

## Root cause

\`services/fishStockingPhotos.service.ts:74\` was generating **presigned** URLs with a broken \`requestDate\`:

\`\`\`ts
ctx.call('minio.presignedGetObject', {
  ...,
  expires: 60000,
  reqParams: {},
  requestDate: new Date().toDateString(), // ← anchors signing to today 00:00
});
\`\`\`

\`new Date().toDateString()\` strips the time → MinIO signs the URL valid from midnight, dead by ~16:40 local. The bug was latent in the original \`"Going public!"\` commit (2023-05) but didn't surface in normal workday usage.

## Why the right fix is direct URL, not "longer expiry"

Verified that the MinIO bucket \`fishStockingPhotos/\` prefix is **already anonymous-read-enabled** (mirrors biip-medziokle / biip-gyvunai):

\`\`\`bash
$ curl -sS -o /dev/null -w "%{http_code}\\n" \
    https://staging-cdn.biip.lt/zuvinimas-staging/fishStockingPhotos/1.jpg
404               # ← NoSuchKey from MinIO, NOT 403 Forbidden
                  #   = the prefix is publicly GETtable
\`\`\`

So signed URLs were adding no security — they were only adding a failure mode. The proper fix is to mirror the sibling modules: use \`minio.publicUrl\` and return a direct, signature-free, **never-expiring** URL.

## Fix

\`services/fishStockingPhotos.service.ts\`:
- Replace \`minio.presignedGetObject\` with \`minio.publicUrl\` in the \`url\` virtual field.
- Drop all signing params (\`expires\`, \`reqParams\`, \`requestDate\`).

\`services/minio.service.ts\`:
- Update \`publicUrl\` to skip the port segment when it's the conventional HTTP/HTTPS port (80/443). Without this, the URL is \`https://staging-cdn.biip.lt:443/...\` — works, but ugly. Now matches biip-medziokle-api / biip-gyvunai-api output exactly.

## Validation

- ✅ 41/41 tests pass, TypeScript build clean
- ✅ Direct URL verified accessible on staging today
- After merge: photos load for USER and ADMIN at **any** time of day, **any** session, including hours-old open tabs — no expiry exists

## Test plan

- [ ] CI green
- [ ] After merge to main + auto-deploy: load any fishStocking detail with photos → image renders
- [ ] Open the image in a new tab — URL works directly
- [ ] Leave the tab open overnight — image still loads on refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)