### PR TITLE
fix(admin): PATCH /fishStockings/:id EMPTY_FEATURES on WKB round-trip

### DIFF
--- a/services/fishStockings.service.ts
+++ b/services/fishStockings.service.ts
@@ -556,6 +556,11 @@ export default class FishStockingsService extends moleculer.Service {
     },
   })
   async updateFishStocking(ctx: Context<any, UserAuthMeta>) {
+    // Normalize reviewLocation: admin FE round-trips the WKB hex string we
+    // returned on GET; also tolerates {lat,lng} or GeoJSON. Without this
+    // moleculer-postgis throws EMPTY_FEATURES on update.
+    await this.parseReviewLocationField(ctx);
+
     const existingFishStocking: FishStocking = await this.resolveEntities(ctx, {
       id: ctx.params.id,
       populate: 'status',
@@ -1174,7 +1179,7 @@ export default class FishStockingsService extends moleculer.Service {
   async parseReviewLocationField(
     ctx: Context<{
       id?: number;
-      reviewLocation?: { lat: number; lng: number };
+      reviewLocation?: { lat: number; lng: number } | string | any;
     }>,
   ) {
     try {
@@ -1182,6 +1187,21 @@ export default class FishStockingsService extends moleculer.Service {
 
       if (isEmpty(reviewLocation)) {
         ctx.params.reviewLocation = null;
+        return ctx;
+      }
+
+      // Admin FE on PATCH round-trips the WKB hex string we returned on GET
+      // (e.g. "0101000020120D0000..."). That value is already stored — passing
+      // it to moleculer-postgis on update throws EMPTY_FEATURES. Drop the key
+      // so the field is left untouched.
+      if (typeof reviewLocation === 'string') {
+        delete ctx.params.reviewLocation;
+        return ctx;
+      }
+
+      // Already a GeoJSON FeatureCollection (e.g. user redraws on the map) —
+      // pass through as is.
+      if (reviewLocation?.type === 'FeatureCollection') {
         return ctx;
       }
 


### PR DESCRIPTION
## Summary
- Admin's edit screen on \`/proxy/zuvinimas/fishStockings/:id\` failed with \`EMPTY_FEATURES\` on \`reviewLocation\` because the FE GETs the entity, then PATCHes the whole thing back — \`reviewLocation\` is sent as the PostGIS WKB hex string the API just returned (e.g. \`"0101000020120D0000..."\`), and moleculer-postgis can't parse that as GeoJSON on update.
- \`parseReviewLocationField\` now accepts three input shapes:
  - **string** (WKB hex round-trip) → drop the key, leave the stored geometry untouched
  - **GeoJSON FeatureCollection** (e.g. user redrew on the map) → pass through
  - **{lat,lng}** → convert via \`coordinatesToGeometry\` (existing behavior)
- Also wires the hook into \`updateFishStocking\` (admin PATCH). It was previously only invoked from \`register\` / \`updateRegistration\` / \`review\`, so admin updates never normalized the field.

## Test plan
- [x] Existing 41-test integration suite still passes locally
- [x] \`tsc --build\` clean
- [ ] After deploy, re-run the failing admin PATCH (curl in original report) — expect 200 and unchanged \`reviewLocation\` column
- [ ] Admin edits a stocking, hits Save without touching the map → no error
- [ ] Admin edits a stocking, redraws the review location on the map → new geometry persists
- [ ] USER \`register\` / \`updateRegistration\` / \`review\` still work (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)