### PR TITLE
ci: move docker-build CI job to self-hosted am-github-runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,11 @@ permissions: {}
 
 jobs:
   build-test:
+    # TODO(runner-migration): kept on ubuntu-latest for now. Moving to the
+    # self-hosted am-github-runner (ARC) requires the service-container ARC
+    # pattern (job in a container, reach postgres by service name) AND changing
+    # the hard-coded `localhost:5331` connection in package.json's `test` script
+    # — a dev-facing change. See biip-medziokle-api ci.yml for the target shape.
     name: Build and test
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -53,7 +58,7 @@ jobs:
 
   validate-docker-build:
     name: Validate if docker image builds
-    runs-on: ubuntu-latest
+    runs-on: am-github-runner
     timeout-minutes: 10
     permissions:
       contents: read


### PR DESCRIPTION
## Kodėl

Org Actions spending limit blokuoja GitHub-hosted runnerius.

## Kas pakeista (`ci.yml`)

- `validate-docker-build` (be servisų) → `am-github-runner`.
- `build-test` **palieku ant `ubuntu-latest`** su `TODO`: pilna ARC migracija reikalauja service-container pattern'o + dev-facing pakeitimo (hardcode'intas `localhost:5331` package.json `test` skripte; DB pavadinimas nesutampa su servisu; testų failų nėra). Verta atskiro sprendimo.

Deploy'ai migruoja per AplinkosMinisterija/reusable-workflows#32.

🤖 Generated with [Claude Code](https://claude.com/claude-code)