### PR TITLE
zuvinimas: require assigned officer for "Patikrinta" status + allow detaching

### DIFF
--- a/services/fishStockings.service.ts
+++ b/services/fishStockings.service.ts
@@ -48,10 +48,19 @@ const Readable = require('stream').Readable;
 const BATCH_DATA_EXISTS_QUERY =
   'EXISTS (SELECT 1 FROM fish_batches fb WHERE fb.fish_stocking_id = fish_stockings.id AND fb.review_amount IS NOT NULL AND fb.deleted_at is NULL)';
 
+// A signature confirms the officer's participation. Matches the app's
+// isEmpty() check (a non-empty jsonb array) so a null / 'null' / '[]'
+// signature does not count.
+const HAS_SIGNATURE = `(signatures IS NOT NULL AND jsonb_typeof(signatures) = 'array' AND jsonb_array_length(signatures) > 0)`;
+
+// INSPECTED ("Patikrinta") requires an assigned inspector (officer) AND a
+// signature; otherwise a completed stocking is FINISHED ("Įžuvinta").
+const INSPECTED_QUERY = `(${HAS_SIGNATURE} AND inspector IS NOT NULL)`;
+
 const getStatusQueries = (maxTime: number) => ({
   [FishStockingStatus.CANCELED]: `canceled_at IS NOT NULL`,
-  [FishStockingStatus.INSPECTED]: `signatures IS NOT NULL AND ${BATCH_DATA_EXISTS_QUERY}`,
-  [FishStockingStatus.FINISHED]: `signatures IS NULL AND ${BATCH_DATA_EXISTS_QUERY}`,
+  [FishStockingStatus.INSPECTED]: `${INSPECTED_QUERY} AND ${BATCH_DATA_EXISTS_QUERY}`,
+  [FishStockingStatus.FINISHED]: `NOT ${INSPECTED_QUERY} AND ${BATCH_DATA_EXISTS_QUERY}`,
   [FishStockingStatus.ONGOING]: `NOW() < date_trunc('day',event_time + '00:00:00') + INTERVAL '${maxTime} days' AND NOW() > date_trunc('day',event_time + '00:00:00') AND NOT ${BATCH_DATA_EXISTS_QUERY} AND canceled_at is NULL`,
   [FishStockingStatus.UPCOMING]: `NOW() < date_trunc('day',event_time + '00:00:00') AND NOT ${BATCH_DATA_EXISTS_QUERY} AND canceled_at is NULL`,
   [FishStockingStatus.NOT_FINISHED]: `NOW() > date_trunc('day',event_time + '00:00:00') + INTERVAL '10 days' AND NOT ${BATCH_DATA_EXISTS_QUERY} AND canceled_at is NULL`,
@@ -339,6 +348,7 @@ export type FishStocking<
       inspector: {
         type: 'object',
         required: false,
+        nullable: true,
         properties: {
           firstName: 'string',
           lastName: 'string',
@@ -526,7 +536,8 @@ export default class FishStockingsService extends moleculer.Service {
           },
         },
       },
-      inspector: 'number|optional',
+      // null detaches the assigned inspector (officer).
+      inspector: { type: 'number', optional: true, nullable: true },
       canceledAt: 'string|optional',
     },
   })
@@ -607,6 +618,15 @@ export default class FishStockingsService extends moleculer.Service {
     }
 
     const fishStockingBeforeUpdate = await this.resolveEntities(ctx);
+
+    // Detach the assigned inspector (officer). Admins — including the assigned
+    // officer, who is also an admin — clear the assignment when the officer did
+    // not actually take part. Without an inspector a completed stocking falls
+    // back to "Įžuvinta" (FINISHED) per the status rule.
+    if (ctx.params.inspector === null) {
+      return this.updateEntity(ctx, { ...ctx.params, inspector: null });
+    }
+
     if (ctx.params.inspector) {
       const inspector: any = await ctx.call('auth.users.get', {
         id: ctx.params.inspector,

--- a/test/unit/fishStockingStatus.spec.ts
+++ b/test/unit/fishStockingStatus.spec.ts
@@ -1,0 +1,50 @@
+'use strict';
+
+// Unit tests for the INSPECTED ("Patikrinta") status rule:
+// a completed stocking is INSPECTED only when it has BOTH a signature AND an
+// assigned inspector (officer); otherwise it is FINISHED ("Įžuvinta").
+import { getStatus, isInspected } from '../../utils/functions';
+import { FishStockingStatus } from '../../types';
+
+const reviewedBatches = [{ reviewAmount: 5 }] as any;
+const unreviewedBatches = [{ reviewAmount: null }] as any;
+const settings = { maxTimeForRegistration: 10 } as any;
+const ctx = {} as any;
+
+const stocking = (over: any = {}) =>
+  ({
+    canceledAt: null,
+    signatures: null,
+    inspector: null,
+    eventTime: new Date(),
+    ...over,
+  } as any);
+
+describe('fishStocking status — INSPECTED requires signature + inspector', () => {
+  it('signature + inspector -> INSPECTED', () => {
+    const fs = stocking({ signatures: [{ signedBy: 'x' }], inspector: { id: 1 } });
+    expect(isInspected(fs, reviewedBatches)).toBe(true);
+    expect(getStatus(ctx, fs, reviewedBatches, settings)).toBe(FishStockingStatus.INSPECTED);
+  });
+
+  it('signature but NO inspector -> FINISHED', () => {
+    const fs = stocking({ signatures: [{ signedBy: 'x' }], inspector: null });
+    expect(isInspected(fs, reviewedBatches)).toBe(false);
+    expect(getStatus(ctx, fs, reviewedBatches, settings)).toBe(FishStockingStatus.FINISHED);
+  });
+
+  it('inspector but NO signature -> FINISHED', () => {
+    const fs = stocking({ signatures: null, inspector: { id: 1 } });
+    expect(getStatus(ctx, fs, reviewedBatches, settings)).toBe(FishStockingStatus.FINISHED);
+  });
+
+  it('empty signature array -> FINISHED', () => {
+    const fs = stocking({ signatures: [], inspector: { id: 1 } });
+    expect(getStatus(ctx, fs, reviewedBatches, settings)).toBe(FishStockingStatus.FINISHED);
+  });
+
+  it('not reviewed -> not INSPECTED', () => {
+    const fs = stocking({ signatures: [{ signedBy: 'x' }], inspector: { id: 1 } });
+    expect(isInspected(fs, unreviewedBatches)).toBe(false);
+  });
+});

--- a/utils/functions.ts
+++ b/utils/functions.ts
@@ -148,7 +148,8 @@ export const isReviewed = (fishStocking: FishStocking, batches: FishBatch[]) => 
 
 export const isInspected = (fishStocking: FishStocking, batches: FishBatch[]) => {
   const reviewed = isReviewed(fishStocking, batches);
-  return reviewed && !isEmpty(fishStocking.signatures);
+  // "Patikrinta" requires an assigned inspector (officer) AND a signature.
+  return reviewed && !isEmpty(fishStocking.signatures) && !isEmpty(fishStocking.inspector);
 };
 
 export const isOngoing = (fishStocking: FishStocking, settings: Setting) => {


### PR DESCRIPTION
## What
- "Patikrinta" (INSPECTED) now requires BOTH a signature AND an assigned officer (`inspector`). Other completed stockings are "Įžuvinta" (FINISHED).
- Admins — and the assigned officer, who is also an admin — can detach the officer when they did not take part: `PATCH /fishStockings/:id` with `inspector: null`.

## Why
Officers were assigned to stockings they did not actually attend, yet the stocking still showed "Patikrinta", and there was no way to remove a wrongly-assigned officer.

## Notes
- Status is a virtual field, so the rule applies to all stockings: existing completed + signed stockings without an assigned officer move from "Patikrinta" to "Įžuvinta".
- Public statistics / fish counts are unchanged (the FINISHED + INSPECTED union is identical).
- Pairs with the biip-admin-web PR #504 that adds the UI to detach the officer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)