### PR TITLE
zuvinimas: detaching the officer writes NULL, not {} (fix "undefined undefined")

### DIFF
--- a/services/fishStockings.service.ts
+++ b/services/fishStockings.service.ts
@@ -623,8 +623,17 @@ export default class FishStockingsService extends moleculer.Service {
     // officer, who is also an admin — clear the assignment when the officer did
     // not actually take part. Without an inspector a completed stocking falls
     // back to "Įžuvinta" (FINISHED) per the status rule.
+    //
+    // Use a raw $set update: @moleculer/database coerces a null value for an
+    // object field that declares `properties` into `{}` during validation
+    // (validation.js _validateObject), which the admin UI then renders as
+    // "undefined undefined". A raw update skips that and writes a real NULL.
     if (ctx.params.inspector === null) {
-      return this.updateEntity(ctx, { ...ctx.params, inspector: null });
+      return this.updateEntity(
+        ctx,
+        { id: ctx.params.id, $set: { inspector: null } },
+        { raw: true },
+      );
     }
 
     if (ctx.params.inspector) {

--- a/test/integration/api/fishStockings/inspectorDetach.spec.ts
+++ b/test/integration/api/fishStockings/inspectorDetach.spec.ts
@@ -1,0 +1,94 @@
+'use strict';
+// Regression: detaching the assigned inspector (officer) must clear it to NULL,
+// not coerce it to `{}`. @moleculer/database turns a null value for an object
+// field that declares `properties` into `{}` during write validation, which the
+// admin UI then renders as "undefined undefined". updateFishStocking clears via
+// a raw $set update to write a real NULL instead.
+
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
+import { ApiHelper } from '../../../helpers/api';
+
+const request = require('supertest');
+
+const apiHelper = new ApiHelper();
+const apiService = apiHelper.bootServices();
+
+beforeAll(async () => {
+  await apiHelper.start();
+  await apiHelper.setup();
+});
+afterAll(async () => {
+  await apiHelper.stop();
+});
+
+function registerPayload() {
+  return {
+    eventTime: new Date(Date.now() + 5 * 86400000).toISOString(),
+    phone: '+37060000000',
+    assignedTo: apiHelper.ownerA.appUserId,
+    location: {
+      cadastral_id: '12345',
+      name: 'Test pond',
+      municipality: { id: 1, name: 'Test municipality' },
+    },
+    geom: {
+      type: 'FeatureCollection',
+      features: [
+        { type: 'Feature', geometry: { type: 'Point', coordinates: [25.0, 55.0] }, properties: {} },
+      ],
+    },
+    batches: [{ fishType: apiHelper.fishTypeId, fishAge: apiHelper.fishAgeId, amount: 100 }],
+    fishOrigin: 'GROWN',
+    fishOriginCompanyName: 'TestCompany',
+  };
+}
+
+describe('fishStockings inspector detach', () => {
+  let fishStockingId: number;
+  let officerId: number;
+
+  beforeAll(async () => {
+    const officer = apiHelper.authStore.addUser({
+      type: 'ADMIN',
+      firstName: 'Insp',
+      lastName: 'Ector',
+      phone: '+37060000009',
+      municipalities: [1],
+    });
+    officerId = officer.id;
+
+    const res = await request(apiService.server)
+      .post('/zuvinimasnew/api/fishStockings/register')
+      .set(
+        apiHelper.headers({ token: apiHelper.ownerA.token, profile: apiHelper.tenantA.tenantId }),
+      )
+      .send(registerPayload());
+    expect(res.status).toBe(200);
+    fishStockingId = Number(res.body.id);
+  });
+
+  it('assigns the officer -> inspector populated', async () => {
+    const res = await request(apiService.server)
+      .patch(`/zuvinimasnew/api/fishStockings/${fishStockingId}`)
+      .set(apiHelper.headers({ token: apiHelper.admin.token }))
+      .send({ inspector: officerId });
+    expect(res.status).toBe(200);
+    expect(res.body.inspector).toMatchObject({ firstName: 'Insp', organization: 'AAD' });
+  });
+
+  it('detaches the officer -> inspector is null, not {}', async () => {
+    const res = await request(apiService.server)
+      .patch(`/zuvinimasnew/api/fishStockings/${fishStockingId}`)
+      .set(apiHelper.headers({ token: apiHelper.admin.token }))
+      .send({ inspector: null });
+    expect(res.status).toBe(200);
+    expect(res.body.inspector ?? null).toBeNull();
+
+    // confirm it persisted
+    const get = await request(apiService.server)
+      .get(`/zuvinimasnew/api/fishStockings/${fishStockingId}`)
+      .set(apiHelper.headers({ token: apiHelper.admin.token }))
+      .expect(200);
+    expect(get.body.inspector ?? null).toBeNull();
+  });
+});


### PR DESCRIPTION
## What
After PR #101, detaching the assigned officer left the admin UI showing **"undefined undefined"** instead of "Nepriskirta".

## Why
`@moleculer/database` coerces a `null` value for an object field that declares `properties` (the `inspector` field) into `{}` during write validation (`validation.js` `_validateObject`). So `updateFishStocking({ inspector: null })` stored `{}::jsonb` — a truthy, nameless object the picker rendered as "undefined undefined".

## Fix
Clear the officer via a raw `$set` update (`updateEntity(..., { raw: true })`), which skips that validation and writes a real `NULL`. Adds a regression test (`inspectorDetach.spec.ts`) that fails on the old code (`Received: {}`) and passes now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)