### PR TITLE
zuvinimas: "Patikrinta" requires the assigned inspector's signature

### DIFF
--- a/services/fishStockings.service.ts
+++ b/services/fishStockings.service.ts
@@ -48,10 +48,17 @@ const Readable = require('stream').Readable;
 const BATCH_DATA_EXISTS_QUERY =
   'EXISTS (SELECT 1 FROM fish_batches fb WHERE fb.fish_stocking_id = fish_stockings.id AND fb.review_amount IS NOT NULL AND fb.deleted_at is NULL)';
 
-// A signature confirms the officer's participation. Matches the app's
-// isEmpty() check (a non-empty jsonb array) so a null / 'null' / '[]'
-// signature does not count.
-const HAS_SIGNATURE = `(signatures IS NOT NULL AND jsonb_typeof(signatures) = 'array' AND jsonb_array_length(signatures) > 0)`;
+// A signature confirms the assigned officer's participation. The review form
+// pre-fills the inspector's name/organization with an empty `signature`, so a
+// non-empty array is not enough — at least one entry must carry an actual
+// signature value.
+const HAS_SIGNATURE = `EXISTS (
+  SELECT 1
+  FROM jsonb_array_elements(
+    CASE WHEN jsonb_typeof(signatures) = 'array' THEN signatures ELSE '[]'::jsonb END
+  ) AS sig
+  WHERE COALESCE(sig->>'signature', '') <> ''
+)`;
 
 // INSPECTED ("Patikrinta") requires an assigned inspector (officer) AND a
 // signature; otherwise a completed stocking is FINISHED ("Įžuvinta").

--- a/test/unit/fishStockingStatus.spec.ts
+++ b/test/unit/fishStockingStatus.spec.ts
@@ -1,8 +1,11 @@
 'use strict';
 
 // Unit tests for the INSPECTED ("Patikrinta") status rule:
-// a completed stocking is INSPECTED only when it has BOTH a signature AND an
-// assigned inspector (officer); otherwise it is FINISHED ("Įžuvinta").
+// a completed stocking is INSPECTED only when it has an assigned inspector
+// (officer) who ACTUALLY SIGNED (a signature entry carrying a real signature
+// value); otherwise it is FINISHED ("Įžuvinta"). The review form pre-fills the
+// inspector's name/organization with an empty `signature`, so a non-empty
+// signatures array alone must NOT count as inspected.
 import { getStatus, isInspected } from '../../utils/functions';
 import { FishStockingStatus } from '../../types';
 
@@ -10,6 +13,11 @@ const reviewedBatches = [{ reviewAmount: 5 }] as any;
 const unreviewedBatches = [{ reviewAmount: null }] as any;
 const settings = { maxTimeForRegistration: 10 } as any;
 const ctx = {} as any;
+
+const signed = [{ signedBy: 'x', organization: 'org', signature: 'data:image/png;base64,AAAA' }];
+// Pre-filled inspector slot the fish-stocker submitted without the inspector
+// actually drawing a signature.
+const unsigned = [{ signedBy: 'x', organization: 'org', signature: '' }];
 
 const stocking = (over: any = {}) =>
   ({
@@ -20,15 +28,21 @@ const stocking = (over: any = {}) =>
     ...over,
   } as any);
 
-describe('fishStocking status — INSPECTED requires signature + inspector', () => {
-  it('signature + inspector -> INSPECTED', () => {
-    const fs = stocking({ signatures: [{ signedBy: 'x' }], inspector: { id: 1 } });
+describe('fishStocking status — INSPECTED requires assigned inspector signature', () => {
+  it('real inspector signature + inspector -> INSPECTED', () => {
+    const fs = stocking({ signatures: signed, inspector: { id: 1 } });
     expect(isInspected(fs, reviewedBatches)).toBe(true);
     expect(getStatus(ctx, fs, reviewedBatches, settings)).toBe(FishStockingStatus.INSPECTED);
   });
 
-  it('signature but NO inspector -> FINISHED', () => {
-    const fs = stocking({ signatures: [{ signedBy: 'x' }], inspector: null });
+  it('assigned inspector but signature NOT drawn (empty signature) -> FINISHED', () => {
+    const fs = stocking({ signatures: unsigned, inspector: { id: 1 } });
+    expect(isInspected(fs, reviewedBatches)).toBe(false);
+    expect(getStatus(ctx, fs, reviewedBatches, settings)).toBe(FishStockingStatus.FINISHED);
+  });
+
+  it('real signature but NO inspector -> FINISHED', () => {
+    const fs = stocking({ signatures: signed, inspector: null });
     expect(isInspected(fs, reviewedBatches)).toBe(false);
     expect(getStatus(ctx, fs, reviewedBatches, settings)).toBe(FishStockingStatus.FINISHED);
   });
@@ -44,7 +58,7 @@ describe('fishStocking status — INSPECTED requires signature + inspector', () 
   });
 
   it('not reviewed -> not INSPECTED', () => {
-    const fs = stocking({ signatures: [{ signedBy: 'x' }], inspector: { id: 1 } });
+    const fs = stocking({ signatures: signed, inspector: { id: 1 } });
     expect(isInspected(fs, unreviewedBatches)).toBe(false);
   });
 });

--- a/utils/functions.ts
+++ b/utils/functions.ts
@@ -146,10 +146,17 @@ export const isReviewed = (fishStocking: FishStocking, batches: FishBatch[]) => 
   return !batchesDataNotFilled;
 };
 
+// The review form pre-fills the assigned inspector's name/organization with an
+// empty `signature`, so a non-empty array does not prove the inspector signed.
+// Only an entry carrying an actual signature value counts.
+const hasSignature = (fishStocking: FishStocking) =>
+  Array.isArray(fishStocking.signatures) &&
+  fishStocking.signatures.some((signature: any) => !isEmpty(signature?.signature));
+
 export const isInspected = (fishStocking: FishStocking, batches: FishBatch[]) => {
   const reviewed = isReviewed(fishStocking, batches);
-  // "Patikrinta" requires an assigned inspector (officer) AND a signature.
-  return reviewed && !isEmpty(fishStocking.signatures) && !isEmpty(fishStocking.inspector);
+  // "Patikrinta" requires an assigned inspector (officer) who actually signed.
+  return reviewed && !isEmpty(fishStocking.inspector) && hasSignature(fishStocking);
 };
 
 export const isOngoing = (fishStocking: FishStocking, settings: Setting) => {


### PR DESCRIPTION
## What
A completed fish stocking is now marked INSPECTED ("Patikrinta") only when the assigned inspector (officer) has **actually signed**. Without a real inspector signature it stays FINISHED ("Įžuvinta").

## Why
The review form pre-fills the assigned inspector's name/organization into `signatures` with an empty `signature` value, and the web validation does not require the signature drawing. The status logic counted any non-empty `signatures` array as signed, so an assigned-but-unsigned inspector wrongly flipped the status to "Patikrinta".

## Notes
- Fix applied in both status layers so they stay consistent: the virtual `status` field (`utils/functions.ts`) and the SQL status filter (`HAS_SIGNATURE` in `fishStockings.service.ts`). The SQL guard was validated against null / empty / scalar / prefilled-empty / real-signature inputs.
- Unit tests updated + regression case added (`test/unit/fishStockingStatus.spec.ts`): assigned inspector with an empty signature now resolves to FINISHED.
- No migration, no env changes.