### PR TITLE
fix(photos): restore presigned URLs — prod CDN objects are private

### DIFF
--- a/services/fishStockingPhotos.service.ts
+++ b/services/fishStockingPhotos.service.ts
@@ -66,20 +66,24 @@ export type FishStockingPhoto<
       url: {
         virtual: true,
         get({ entity, ctx }: FieldHookCallback) {
-          // Use the direct public URL (no signature), not a presigned URL.
-          // The MinIO `fishStockingPhotos/` prefix is configured for anonymous
-          // s3:GetObject (verified: direct curl returns NoSuchKey on a missing
-          // object instead of 403), so signed URLs add nothing but a failure
-          // mode — the old code passed `requestDate: new Date().toDateString()`
-          // which anchored the signing timestamp to today's 00:00, so the URL
-          // would die mid-day and the UI showed broken images plus a spinner
-          // (S3 returned `<Code>Forbidden</Code><Message>Request has expired
-          // </Message>`). publicUrl has no expiry — photos are visible to
-          // USER and ADMIN whenever they open the stocking page. Mirror of
-          // how biip-medziokle-api / biip-gyvunai-api serve their photos.
-          return ctx.call('minio.publicUrl', {
+          // Must be a presigned URL. On staging/production MINIO_ENDPOINT is
+          // cdn.biip.lt, which fronts EMC ECS (VITC) — objects there are
+          // private, so an unsigned URL returns 403 AccessDenied for every
+          // photo (a missing object still returns 404 NoSuchKey, which is NOT
+          // proof of anonymous read access).
+          return ctx.call('minio.presignedGetObject', {
             bucketName: process.env.MINIO_BUCKET,
             objectName: this.getObjectName(entity),
+            // 24h: comfortably outlives any Redis-cached (1h TTL) response
+            // that embeds the URL, while still expiring leaked links.
+            expires: 60 * 60 * 24,
+            // moleculer-minio passes all args positionally into minio-js,
+            // whose validation rejects undefined — so reqParams and
+            // requestDate are effectively REQUIRED. requestDate must carry
+            // the time of day: toISOString(), never toDateString() (that
+            // anchors the signature to 00:00 and the URL dies mid-day).
+            reqParams: {},
+            requestDate: new Date().toISOString(),
           });
         },
       },

--- a/services/minio.service.ts
+++ b/services/minio.service.ts
@@ -1,7 +1,7 @@
 'use strict';
 
-import Moleculer, { Context } from 'moleculer';
-import { Action, Service } from 'moleculer-decorators';
+import Moleculer from 'moleculer';
+import { Service } from 'moleculer-decorators';
 // @ts-ignore
 import MinioMixin from 'moleculer-minio';
 
@@ -47,39 +47,6 @@ import MinioMixin from 'moleculer-minio';
   },
 })
 export default class MinioService extends Moleculer.Service {
-  @Action({
-    visibility: 'protected',
-    params: {
-      bucketName: 'string',
-      objectName: 'string',
-    },
-  })
-  publicUrl(
-    ctx: Context<{
-      bucketName: string;
-      objectName: string;
-    }>,
-  ) {
-    // Drop the port segment for the conventional HTTP(S) ports so the URL
-    // matches what the CDN/Caddy in front of MinIO actually serves on
-    // staging/production (`https://staging-cdn.biip.lt/<bucket>/<object>`,
-    // no `:443` suffix). Mirror of biip-medziokle-api / biip-gyvunai-api.
-    let portString = '';
-    if (![80, 443].includes(Number(this.client.port))) {
-      portString = `:${this.client.port}`;
-    }
-    return (
-      this.client.protocol +
-      '//' +
-      this.client.host +
-      portString +
-      '/' +
-      ctx.params.bucketName +
-      '/' +
-      ctx.params.objectName
-    );
-  }
-
   async started() {
     const bucketExists: boolean = await this.actions.bucketExists({
       bucketName: process.env.MINIO_BUCKET,


### PR DESCRIPTION
## What

Fish stocking photos are broken in production since 1.4.7 (2026-07-07): every photo URL returns `403 AccessDenied`. This restores presigned photo URLs — the mechanism that worked until 1.4.7 — with the mid-day-expiry defect fixed.

## Why

1.4.7 switched photo URLs to unsigned public URLs on the assumption that the `fishStockingPhotos/` prefix allows anonymous `s3:GetObject`. Production `cdn.biip.lt` fronts EMC ECS (VITC) where the objects are private, so every existing photo 403s (verified live; a missing object returning `404 NoSuchKey` is not proof of anonymous read).

The original pre-1.4.7 defect was `requestDate: new Date().toDateString()`, which anchors the signature to today's 00:00 UTC so URLs died every evening (~18:40–19:40 LT). Now `toISOString()` keeps the time of day and the URL is valid a full 24h from generation. `reqParams: {}` and `requestDate` stay because moleculer-minio passes args positionally into minio-js, whose validation rejects `undefined`.

Also drops the now-unused `minio.publicUrl` action.

## Notes

Task: https://github.com/orgs/AplinkosMinisterija/projects/18/views/7?pane=issue&itemId=213957363 (problem #2 — photos never load; problem #1, the mistakenly canceled stocking, is being handled separately via DB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)